### PR TITLE
Closes #301 Add support for time_continue query string

### DIFF
--- a/js/everything.js
+++ b/js/everything.js
@@ -645,10 +645,18 @@ $(function() {
         event.preventDefault();
         var formValue = $.trim($("#v").val());
         var formValueTime = /[?&]t=(\d*)/g.exec(formValue);
+        var formValueTimeContinue = /[?&]time_continue=(\d*)/g.exec(formValue);
+
         if (formValueTime && formValueTime.length > 1) {
             formValueTime = parseInt(formValueTime[1], 10);
             formValue = formValue.replace(/&t=\d*$/g, "");
         }
+
+        if (formValueTimeContinue && formValueTimeContinue.length > 1) {
+            formValueTimeContinue = parseInt(formValueTimeContinue[1], 10);
+            formValue = formValue.replace(/&time_continue=\d*$/g, "");
+        }
+
         if (formValue) {
             var videoID = wrapParseYouTubeVideoID(formValue, true);
             ga("send", "event", "form submitted", videoID);
@@ -672,7 +680,7 @@ $(function() {
                             window.location.href = makeSearchURL(formValue);
                         }
                         else {
-                            window.location.href = makeListenURL(videoID, formValueTime);
+                            window.location.href = makeListenURL(videoID, formValueTime || formValueTimeContinue);
                         }
                     }
                 }).fail(function(jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
Closes #301

- Add support for time_continue query string. 
Example: https://www.youtube.com/watch?time_continue=50&v=XYZ should play the video starting at 0:50.

### Important
Mark with [x] to select. Leave as [ ] to unselect.

### Motivation and Context
- [ ] Why is this change required? What problem does it solve?
- [x] If it fixes an open issue, include the text `Closes #1` (where 1 would be the issue number) to your commit message.

### Types of changes
What types of changes does your code introduce? Check all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description
- [x] Describe your changes in detail.

### Final checklist:
Go over all the following points and check all the boxes that apply  
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](.github/CONTRIBUTING.md) guidelines.
- [ ] All tests passed.